### PR TITLE
Define stepValue on ThermostatTargetHCstateCharacteristic

### DIFF
--- a/src/DB.c
+++ b/src/DB.c
@@ -204,7 +204,7 @@ const HAPUInt8Characteristic ThermostatTargetHCstateCharacteristic = {
                            .supportsDisconnectedNotification = true,
                            .readableWithoutSecurity = false,
                            .writableWithoutSecurity = false}},
-    .constraints = {.minimumValue = 0, .maximumValue = 3},
+    .constraints = {.minimumValue = 0, .maximumValue = 3, .stepValue = 1},
     .callbacks = {.handleRead = HandleThermostatTargetHCstateRead,
                   .handleWrite = HandleThermostatTargetHCstateWrite}};
 


### PR DESCRIPTION
Define stepValue on ThermostatTargetHCstateCharacteristic at DB.c to solve issues with system that doesn't manage correctly misconfigured params like this. As it happens on Home Assistant 2023.09.01.